### PR TITLE
right click to send window to back

### DIFF
--- a/PortionOfScreen/PortionOfScreen.cpp
+++ b/PortionOfScreen/PortionOfScreen.cpp
@@ -139,6 +139,10 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         DialogBox(hInst, MAKEINTRESOURCE(IDD_ABOUTBOX), hWnd, About);
         break;
 
+    case WM_RBUTTONUP:
+        SetWindowPos(hWnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
+        break;
+
     case WM_SETFOCUS:
         SetLayeredWindowAttributes(hWnd, RGB(255, 255, 255), 128, LWA_ALPHA);
         SetWindowLong(hWnd, GWL_EXSTYLE, WS_EX_LAYERED | WS_EX_TOPMOST);


### PR DESCRIPTION
Adds feature to address #3. The left click still brings up the about window. A right click sends the main window to the back.